### PR TITLE
Migrate to lucide icons and apply dark mode tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Unreleased
+- migrate inline icons to `lucide-react`
+- update tailwind config to class-based dark mode
+- apply semantic color tokens in UI components

--- a/apps/web/src/components/layout/BackToTop.tsx
+++ b/apps/web/src/components/layout/BackToTop.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { ArrowUp } from 'lucide-react'
 
 export function BackToTop() {
   const [isVisible, setIsVisible] = useState(false)
@@ -20,14 +21,12 @@ export function BackToTop() {
   if (!isVisible) return null
 
   return (
-    <button 
+    <button
       onClick={scrollToTop}
-      className="fixed bottom-8 right-8 bg-blue-600 dark:bg-blue-800 text-white p-3 rounded-full shadow-lg hover:bg-blue-700 dark:hover:bg-blue-700 transition-colors z-50"
+      className="fixed bottom-8 right-8 bg-primary text-primary-foreground p-3 rounded-full shadow-lg hover:bg-primary/80 transition-colors z-50"
       aria-label="Back to top"
     >
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
-      </svg>
+      <ArrowUp className="w-6 h-6" />
     </button>
   )
-} 
+}

--- a/apps/web/src/components/layout/Breadcrumb.tsx
+++ b/apps/web/src/components/layout/Breadcrumb.tsx
@@ -68,7 +68,7 @@ export function BreadcrumbNav() {
   }
 
   return (
-    <nav className="bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
+    <nav className="bg-muted dark:bg-muted border-b border-border">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
         <Breadcrumb>
           <BreadcrumbList>

--- a/apps/web/src/components/layout/Footer.tsx
+++ b/apps/web/src/components/layout/Footer.tsx
@@ -1,17 +1,17 @@
 export function Footer() {
   return (
-    <footer className="bg-gray-900 dark:bg-gray-950 text-white">
+    <footer className="bg-background text-foreground">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           {/* Logo & Description */}
           <div className="col-span-1 md:col-span-2">
             <div className="flex items-center space-x-2 mb-4">
-              <div className="w-8 h-8 bg-blue-600 dark:bg-blue-800 rounded-lg flex items-center justify-center">
-                <span className="text-white font-bold text-sm">RK</span>
+              <div className="w-8 h-8 bg-primary text-primary-foreground rounded-lg flex items-center justify-center">
+                <span className="font-bold text-sm">RK</span>
               </div>
               <span className="text-xl font-bold">RevierKompass</span>
             </div>
-            <p className="text-gray-400 dark:text-gray-500 max-w-md">
+            <p className="text-muted-foreground max-w-md">
               Ihre zuverlässige Anwendung für die optimale Routenplanung 
               zu Polizeistationen in Baden-Württemberg.
             </p>
@@ -21,9 +21,9 @@ export function Footer() {
           <div>
             <h3 className="text-lg font-semibold mb-4">Quick Links</h3>
             <ul className="space-y-2">
-              <li><a href="/" className="text-gray-400 dark:text-gray-500 hover:text-white">Home</a></li>
-              <li><a href="/wizard/step1" className="text-gray-400 dark:text-gray-500 hover:text-white">Route planen</a></li>
-              <li><a href="/about" className="text-gray-400 dark:text-gray-500 hover:text-white">Über uns</a></li>
+              <li><a href="/" className="text-muted-foreground hover:text-foreground">Home</a></li>
+              <li><a href="/wizard/step1" className="text-muted-foreground hover:text-foreground">Route planen</a></li>
+              <li><a href="/about" className="text-muted-foreground hover:text-foreground">Über uns</a></li>
             </ul>
           </div>
 
@@ -31,15 +31,15 @@ export function Footer() {
           <div>
             <h3 className="text-lg font-semibold mb-4">Kontakt</h3>
             <ul className="space-y-2">
-              <li className="text-gray-400 dark:text-gray-500">Baden-Württemberg</li>
-              <li className="text-gray-400 dark:text-gray-500">Deutschland</li>
-              <li><a href="mailto:info@revierkompass.de" className="text-gray-400 dark:text-gray-500 hover:text-white">info@revierkompass.de</a></li>
+              <li className="text-muted-foreground">Baden-Württemberg</li>
+              <li className="text-muted-foreground">Deutschland</li>
+              <li><a href="mailto:info@revierkompass.de" className="text-muted-foreground hover:text-foreground">info@revierkompass.de</a></li>
             </ul>
           </div>
         </div>
 
-        <div className="border-t border-gray-800 dark:border-gray-700 mt-8 pt-8 text-center">
-          <p className="text-gray-400 dark:text-gray-500">
+        <div className="border-t border-border mt-8 pt-8 text-center">
+          <p className="text-muted-foreground">
             © 2025 RevierKompass. Alle Rechte vorbehalten.
           </p>
         </div>

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Link, useLocation } from '@tanstack/react-router'
+import { User, Menu } from 'lucide-react'
 import { ModeToggle } from '../theme-provider'
 
 export function Header() {
@@ -10,31 +11,31 @@ export function Header() {
   const isWizard = location.pathname.startsWith('/wizard')
 
   return (
-    <header className="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 shadow-sm">
+    <header className="bg-background border-b border-border shadow-sm">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           {/* Logo */}
           <div className="flex items-center">
             <Link to="/" className="flex items-center space-x-2">
-              <div className="w-8 h-8 bg-blue-600 dark:bg-blue-800 rounded-lg flex items-center justify-center">
-                <span className="text-white font-bold text-sm">RK</span>
+              <div className="w-8 h-8 bg-primary text-primary-foreground rounded-lg flex items-center justify-center">
+                <span className="font-bold text-sm">RK</span>
               </div>
-              <span className="text-xl font-bold text-gray-900 dark:text-white">RevierKompass</span>
+              <span className="text-xl font-bold text-foreground">RevierKompass</span>
             </Link>
           </div>
 
           {/* Navigation Desktop */}
           <nav className="hidden md:flex items-center space-x-8">
-            <Link to="/" className="text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
+            <Link to="/" className="text-muted-foreground hover:text-primary transition-colors">
               Home
             </Link>
-            <Link 
-              to="/wizard/step1" 
-              className={`text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors ${isWizard ? 'text-blue-600 dark:text-blue-400 font-medium' : ''}`}
+            <Link
+              to="/wizard/step1"
+              className={`text-muted-foreground hover:text-primary transition-colors ${isWizard ? 'text-primary font-medium' : ''}`}
             >
               Wizard
             </Link>
-            <Link to="/about" className="text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
+            <Link to="/about" className="text-muted-foreground hover:text-primary transition-colors">
               Über uns
             </Link>
           </nav>
@@ -45,24 +46,20 @@ export function Header() {
             <ModeToggle />
 
             {/* Login Button */}
-            <Link 
-              to="/login" 
-              className="bg-blue-600 dark:bg-blue-800 text-white px-4 py-2 rounded-lg flex items-center space-x-2 hover:bg-blue-700 dark:hover:bg-blue-700 transition-colors"
+            <Link
+              to="/login"
+              className="bg-primary text-primary-foreground px-4 py-2 rounded-lg flex items-center space-x-2 hover:bg-primary/90 transition-colors"
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-              </svg>
+              <User className="w-4 h-4" />
               <span className="hidden sm:inline">Login</span>
             </Link>
 
             {/* Mobile Menu Button */}
-            <button 
-              className="md:hidden p-2 text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+            <button
+              className="md:hidden p-2 text-muted-foreground hover:text-primary transition-colors"
               onClick={() => setIsMenuOpen(!isMenuOpen)}
             >
-              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16" />
-              </svg>
+              <Menu className="w-6 h-6" />
             </button>
           </div>
         </div>
@@ -70,11 +67,11 @@ export function Header() {
         {/* Mobile Menu */}
         {isMenuOpen && (
           <div className="md:hidden">
-            <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3 border-t border-gray-200 dark:border-gray-700">
-              <Link to="/" className="block px-3 py-2 text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">Home</Link>
-              <Link to="/wizard/step1" className="block px-3 py-2 text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">Wizard</Link>
-              <Link to="/about" className="block px-3 py-2 text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">Über uns</Link>
-              <Link to="/login" className="block px-3 py-2 text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">Login</Link>
+            <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3 border-t border-border">
+              <Link to="/" className="block px-3 py-2 text-muted-foreground hover:text-primary transition-colors">Home</Link>
+              <Link to="/wizard/step1" className="block px-3 py-2 text-muted-foreground hover:text-primary transition-colors">Wizard</Link>
+              <Link to="/about" className="block px-3 py-2 text-muted-foreground hover:text-primary transition-colors">Über uns</Link>
+              <Link to="/login" className="block px-3 py-2 text-muted-foreground hover:text-primary transition-colors">Login</Link>
             </div>
           </div>
         )}

--- a/apps/web/src/components/sections/HeroSection.tsx
+++ b/apps/web/src/components/sections/HeroSection.tsx
@@ -13,15 +13,15 @@ export function HeroSection() {
             in Baden-Württemberg
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Link 
+            <Link
               to="/wizard/step1"
-              className="bg-white dark:bg-gray-100 text-blue-600 dark:text-blue-800 px-8 py-4 rounded-lg font-semibold text-lg hover:bg-gray-50 dark:hover:bg-gray-200 transition-colors"
+              className="bg-background text-primary px-8 py-4 rounded-lg font-semibold text-lg hover:bg-accent transition-colors"
             >
               Jetzt Route planen
             </Link>
-            <Link 
+            <Link
               to="/about"
-              className="border-2 border-white dark:border-gray-100 text-white dark:text-gray-100 px-8 py-4 rounded-lg font-semibold text-lg hover:bg-white dark:hover:bg-gray-100 hover:text-blue-600 dark:hover:text-blue-800 transition-colors"
+              className="border-2 border-foreground text-foreground px-8 py-4 rounded-lg font-semibold text-lg hover:bg-background hover:text-primary transition-colors"
             >
               Mehr erfahren
             </Link>

--- a/apps/web/src/components/theme-provider.tsx
+++ b/apps/web/src/components/theme-provider.tsx
@@ -153,11 +153,11 @@ export function ModeToggle() {
         <Button 
           variant="outline" 
           size="icon"
-          className={`theme-toggle-button transition-all duration-300 
+          className={`theme-toggle-button transition-all duration-300
             ${hover ? 'shadow-lg shadow-blue-500/20' : 'shadow-md'}
-            hover:shadow-blue-500/30 border-gray-300 dark:border-gray-600
-            bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300
-            hover:bg-gray-50 dark:hover:bg-gray-700`}
+            hover:shadow-blue-500/30 border-input
+            bg-background text-foreground
+            hover:bg-accent`}
           onMouseEnter={() => setHover(true)}
           onMouseLeave={() => setHover(false)}
         >
@@ -167,41 +167,41 @@ export function ModeToggle() {
       </DropdownMenuTrigger>
       <DropdownMenuContent 
         align="end" 
-        className="w-48 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 shadow-lg rounded-lg p-1"
+        className="w-48 bg-popover border border-border shadow-lg rounded-lg p-1"
       >
         <DropdownMenuItem 
           onClick={() => setTheme("light")}
-          className="flex items-center px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded cursor-pointer transition-colors"
+          className="flex items-center px-3 py-2 text-sm text-foreground hover:bg-accent rounded cursor-pointer transition-colors"
         >
           <Sun className="mr-3 h-4 w-4" /> Light
         </DropdownMenuItem>
         <DropdownMenuItem 
           onClick={() => setTheme("dark")}
-          className="flex items-center px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded cursor-pointer transition-colors"
+          className="flex items-center px-3 py-2 text-sm text-foreground hover:bg-accent rounded cursor-pointer transition-colors"
         >
           <Moon className="mr-3 h-4 w-4" /> Dark
         </DropdownMenuItem>
         <DropdownMenuItem 
           onClick={() => setTheme("system")}
-          className="flex items-center px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded cursor-pointer transition-colors"
+          className="flex items-center px-3 py-2 text-sm text-foreground hover:bg-accent rounded cursor-pointer transition-colors"
         >
           <Monitor className="mr-3 h-4 w-4" /> System
         </DropdownMenuItem>
         <DropdownMenuItem 
           onClick={() => setTheme("eco")}
-          className="flex items-center px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded cursor-pointer transition-colors"
+          className="flex items-center px-3 py-2 text-sm text-foreground hover:bg-accent rounded cursor-pointer transition-colors"
         >
           <Leaf className="mr-3 h-4 w-4" /> Eco Mode
         </DropdownMenuItem>
         <DropdownMenuItem 
           onClick={() => setTheme("highContrast")}
-          className="flex items-center px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded cursor-pointer transition-colors"
+          className="flex items-center px-3 py-2 text-sm text-foreground hover:bg-accent rounded cursor-pointer transition-colors"
         >
           <Eye className="mr-3 h-4 w-4" /> High Contrast
         </DropdownMenuItem>
-        <DropdownMenuItem 
+        <DropdownMenuItem
           onClick={() => setTheme("auto")}
-          className="flex items-center px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded cursor-pointer transition-colors"
+          className="flex items-center px-3 py-2 text-sm text-foreground hover:bg-accent rounded cursor-pointer transition-colors"
         >
           <Zap className="mr-3 h-4 w-4" /> Auto (AI)
         </DropdownMenuItem>

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -6,55 +6,55 @@ export const Route = createFileRoute('/login')({
 
 function Login() {
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-12 px-4">
+    <div className="min-h-screen bg-background py-12 px-4">
       <div className="max-w-md mx-auto">
         <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
+          <h1 className="text-3xl font-bold text-foreground mb-2">
             Anmelden
           </h1>
-          <p className="text-gray-600 dark:text-gray-400">
+          <p className="text-muted-foreground">
             Melden Sie sich in Ihrem RevierKompass-Konto an.
           </p>
         </div>
 
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8">
+        <div className="bg-card rounded-lg shadow-lg p-8">
           <form className="space-y-6">
             <div>
-              <label htmlFor="email" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              <label htmlFor="email" className="block text-sm font-medium text-foreground mb-2">
                 E-Mail
               </label>
               <input
                 type="email"
                 id="email"
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent dark:bg-gray-700 dark:text-white"
+                className="w-full px-3 py-2 border border-input rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent bg-background text-foreground"
                 placeholder="ihre@email.de"
               />
             </div>
 
             <div>
-              <label htmlFor="password" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              <label htmlFor="password" className="block text-sm font-medium text-foreground mb-2">
                 Passwort
               </label>
               <input
                 type="password"
                 id="password"
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent dark:bg-gray-700 dark:text-white"
+                className="w-full px-3 py-2 border border-input rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent bg-background text-foreground"
                 placeholder="••••••••"
               />
             </div>
 
             <button
               type="submit"
-              className="w-full bg-blue-600 dark:bg-blue-800 text-white py-2 px-4 rounded-lg hover:bg-blue-700 dark:hover:bg-blue-700 transition-colors"
+              className="w-full bg-primary text-primary-foreground py-2 px-4 rounded-lg hover:bg-primary/90 transition-colors"
             >
               Anmelden
             </button>
           </form>
 
           <div className="mt-6 text-center">
-            <p className="text-sm text-gray-600 dark:text-gray-400">
+            <p className="text-sm text-muted-foreground">
               Noch kein Konto?{' '}
-              <a href="#" className="text-blue-600 dark:text-blue-400 hover:underline">
+              <a href="#" className="text-primary hover:underline">
                 Registrieren
               </a>
             </p>

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: "class",
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",

--- a/scripts/report-icons.mjs
+++ b/scripts/report-icons.mjs
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+const mapping = [
+  { old: 'inline user svg', new: 'User (lucide-react)' },
+  { old: 'inline menu svg', new: 'Menu (lucide-react)' },
+  { old: 'inline arrow svg', new: 'ArrowUp (lucide-react)' },
+];
+console.table(mapping);


### PR DESCRIPTION
## Summary
- migrate inline svg icons to `lucide-react`
- enable class-based dark mode in Tailwind config
- apply semantic color tokens across layout components
- add CHANGELOG and icon mapping script

## Testing
- `pnpm test` *(fails: Missing script)*
- `pnpm run build` *(fails: turbo not found because dependencies are missing)*
- `pnpm exec @storybook/test-runner --url http://localhost:6006` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a71ef6dcc8328bcbd3ee0dd0c506d