### PR TITLE
Switch to React SWC plugin in Vitest config

### DIFF
--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vitest/config';
-import react from '@vitejs/plugin-react';
+import react from '@vitejs/plugin-react-swc';
 import path from 'path';
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- update `vitest.config.ts` in the web app to use `@vitejs/plugin-react-swc`

## Testing
- `pnpm --filter @revierkompass/web run test` *(fails: Failed to resolve import "fake-indexeddb/auto")*

------
https://chatgpt.com/codex/tasks/task_e_685adf5dae048328a407d0fd94796ef6