### PR TITLE
Add environment example file for web app

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,12 @@
+# Example environment variables for the web application
+# Copy this file to .env and adjust the values as needed
+
+# Custom API endpoints
+VITE_OSRM_ENDPOINT=https://router.project-osrm.org
+VITE_VALHALLA_ENDPOINT=https://valhalla1.openstreetmap.de
+
+# Cache settings
+VITE_CACHE_SIZE=100
+
+# Monitoring features
+VITE_MONITORING_ENABLED=false

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -52,3 +52,12 @@ export default tseslint.config({
   },
 })
 ```
+
+## Environment Variables
+
+Create a `.env` file based on `.env.example` to configure API endpoints and monitoring options.
+
+- `VITE_OSRM_ENDPOINT` - URL of the primary OSRM service
+- `VITE_VALHALLA_ENDPOINT` - URL of the primary Valhalla service
+- `VITE_CACHE_SIZE` - maximum number of entries stored in the in-memory cache
+- `VITE_MONITORING_ENABLED` - enable performance monitoring when set to `true`


### PR DESCRIPTION
## Summary
- add `.env.example` with common settings for `apps/web`
- document environment variables in the web README

## Testing
- `pnpm lint` *(fails: The number of diagnostics exceeds the limit allowed)*
- `pnpm --filter @revierkompass/web test` *(fails to resolve `fake-indexeddb`)*

------
https://chatgpt.com/codex/tasks/task_e_685adf612bc88328ada86b4180bab0a6